### PR TITLE
Changes for internal use

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Configuration is done via env variables that you set in deployment or configmap.
 * `K8S_EVENTS_STREAMER_SKIP_DELETE_EVENTS` - Skip all events of type DELETED by setting  env variable to `True`. `False` if not defined. Very useful since those events tells you that k8s event was deleted which has no value to you as operator.
 * `K8S_EVENTS_STREAMER_LIST_OF_REASONS_TO_SKIP` - Skip events based on their `reason`. Should contain list of reasons separated by spaces. Very useful since there are a lot of events that doesn't tell you much like image pulled or replica scaled. Send all events if not defined. Recommended reasons to skip `'Scheduled ScalingReplicaSet Pulling Pulled Created Started Killing SuccessfulMountVolume SuccessfulUnMountVolume`. You can see more reasons [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/events/event.go)
 * `K8S_EVENTS_STREAMER_USERS_TO_NOTIFY` - Mention users on warning events, ex `<@andrey9kin> <@slackbot>`. Note! It is important that you use `<>` around user name. Read more [here](https://api.slack.com/docs/message-formatting#linking_to_channels_and_users)
+* `K8S_EVENTS_STREAMER_ENTITY_BLACKLIST` - Space delimited list of regex patterns to exclude events by entity name.
 
 # Deployment
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Configuration is done via env variables that you set in deployment or configmap.
 
 * `K8S_EVENTS_STREAMER_INCOMING_WEB_HOOK_URL` - Slack web hook URL where to send events. Mandatory parameter.
 * `K8S_EVENTS_STREAMER_NAMESPACE` - k8s namespace to collect events from. Will use `default` if not defined
+* `K8S_EVENTS_STREAMER_CLUSTER_NAME` - Arbitrary name of the cluster to include in messages for identification purposes.
 * `K8S_EVENTS_STREAMER_DEBUG` - Enable debug print outs to the log. `False` if not defined. Set to `True` to enable.
 * `K8S_EVENTS_STREAMER_SKIP_DELETE_EVENTS` - Skip all events of type DELETED by setting  env variable to `True`. `False` if not defined. Very useful since those events tells you that k8s event was deleted which has no value to you as operator.
 * `K8S_EVENTS_STREAMER_LIST_OF_REASONS_TO_SKIP` - Skip events based on their `reason`. Should contain list of reasons separated by spaces. Very useful since there are a lot of events that doesn't tell you much like image pulled or replica scaled. Send all events if not defined. Recommended reasons to skip `'Scheduled ScalingReplicaSet Pulling Pulled Created Started Killing SuccessfulMountVolume SuccessfulUnMountVolume`. You can see more reasons [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/events/event.go)

--- a/k8s-events-to-slack-streamer.py
+++ b/k8s-events-to-slack-streamer.py
@@ -1,103 +1,103 @@
 #!/usr/bin/env python3
 
-import os
-import time
 import json
 import logging
-import requests
+import os
+import time
+
 import kubernetes
+import requests
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 def read_env_variable_or_die(env_var_name):
-   value = os.environ.get(env_var_name, '')
-   if value == '':
-       message = 'Env variable {} is not defined or set to empty string. Set it to non-empty string and try again'.format(env_var_name)
-       logger.error(message)
-       raise EnvironmentError(message)
-   return value
+    value = os.environ.get(env_var_name, '')
+    if value == '':
+        message = 'Env variable {} is not defined or set to empty string. Set it to non-empty string and try again'.format(env_var_name)
+        logger.error(message)
+        raise EnvironmentError(message)
+    return value
 
 def post_slack_message(hook_url, message):
-   logger.debug('Posting the following message to {}:\n{}'.format(hook_url, message))
-   headers = {'Content-type': 'application/json'}
-   r = requests.post(hook_url, data = str(message), headers=headers)
+    logger.debug('Posting the following message to {}:\n{}'.format(hook_url, message))
+    headers = {'Content-type': 'application/json'}
+    r = requests.post(hook_url, data = str(message), headers=headers)
 
 def is_message_type_delete(event):
-   return True if event['type'] == 'DELETED' else False
+    return True if event['type'] == 'DELETED' else False
 
 def is_reason_in_skip_list(event, skip_list):
-   return True if event['object'].reason in skip_list else False
+    return True if event['object'].reason in skip_list else False
 
 def format_k8s_event_to_slack_message(event_object, notify=''):
-   event = event_object['object']
-   message = { 
-       'attachments': [ {
-           'color': '#36a64f',
-           'title': event.message,
-           'text': 'event type: {}, event reason: {}'.format(event_object['type'], event.reason),
-           'footer': 'First time seen: {}, Last time seen: {}, Count: {}'.format(event.first_timestamp.strftime('%d/%m/%Y %H:%M:%S %Z'),
-                                                                                 event.last_timestamp.strftime('%d/%m/%Y %H:%M:%S %Z'),
-                                                                                 event.count),
-           'fields': [
-               {
-                   'title': 'Involved object',
-                   'value': 'kind: {}, name: {}, namespace: {}'.format(event.involved_object.kind,
+    event = event_object['object']
+    message = {
+        'attachments': [ {
+            'color': '#36a64f',
+            'title': event.message,
+            'text': 'event type: {}, event reason: {}'.format(event_object['type'], event.reason),
+            'footer': 'First time seen: {}, Last time seen: {}, Count: {}'.format(event.first_timestamp.strftime('%d/%m/%Y %H:%M:%S %Z'),
+                                                                                  event.last_timestamp.strftime('%d/%m/%Y %H:%M:%S %Z'),
+                                                                                  event.count),
+            'fields': [
+                {
+                    'title': 'Involved object',
+                    'value': 'kind: {}, name: {}, namespace: {}'.format(event.involved_object.kind,
                                                                        event.involved_object.name,
                                                                        event.involved_object.namespace),
-                   'short': 'true'
+                    'short': 'true'
                },
                {
-                   'title': 'Metadata',
-                   'value': 'name: {}, creation time: {}'.format(event.metadata.name,
-                                                                 event.metadata.creation_timestamp.strftime('%d/%m/%Y %H:%M:%S %Z')),
-                   'short': 'true'
+                    'title': 'Metadata',
+                    'value': 'name: {}, creation time: {}'.format(event.metadata.name,
+                                                                  event.metadata.creation_timestamp.strftime('%d/%m/%Y %H:%M:%S %Z')),
+                    'short': 'true'
                }
            ],
-        }]
-   }
-   if event.type == 'Warning':
-       message['attachments'][0]['color'] = '#cc4d26'
-       if notify != '':
-           message['text'] = '{} there is a warning for you to check'.format(notify)
+       }]
+    }
+    if event.type == 'Warning':
+        message['attachments'][0]['color'] = '#cc4d26'
+        if notify != '':
+            message['text'] = '{} there is a warning for you to check'.format(notify)
 
-   return json.dumps(message)
+    return json.dumps(message)
 
 def main():
+    if os.environ.get('K8S_EVENTS_STREAMER_DEBUG', False):
+        logger.setLevel(logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
 
-   if os.environ.get('K8S_EVENTS_STREAMER_DEBUG', False):
-       logger.setLevel(logging.DEBUG)
-       logging.basicConfig(level=logging.DEBUG)
-   else:
-       logger.setLevel(logging.INFO)
+    logger.info("Reading configuration...")
+    k8s_namespace_name = os.environ.get('K8S_EVENTS_STREAMER_NAMESPACE', 'default')
+    skip_delete_events = os.environ.get('K8S_EVENTS_STREAMER_SKIP_DELETE_EVENTS', False)
+    reasons_to_skip = os.environ.get('K8S_EVENTS_STREAMER_LIST_OF_REASONS_TO_SKIP', "").split()
+    users_to_notify = os.environ.get('K8S_EVENTS_STREAMER_USERS_TO_NOTIFY', '')
+    slack_web_hook_url = read_env_variable_or_die('K8S_EVENTS_STREAMER_INCOMING_WEB_HOOK_URL')
+    configuration = kubernetes.config.load_incluster_config()
+    v1 = kubernetes.client.CoreV1Api()
+    k8s_watch = kubernetes.watch.Watch()
+    logger.info("Configuration is OK")
 
-   logger.info("Reading configuration...")
-   k8s_namespace_name = os.environ.get('K8S_EVENTS_STREAMER_NAMESPACE', 'default')
-   skip_delete_events = os.environ.get('K8S_EVENTS_STREAMER_SKIP_DELETE_EVENTS', False)
-   reasons_to_skip = os.environ.get('K8S_EVENTS_STREAMER_LIST_OF_REASONS_TO_SKIP', "").split()
-   users_to_notify = os.environ.get('K8S_EVENTS_STREAMER_USERS_TO_NOTIFY', '')
-   slack_web_hook_url = read_env_variable_or_die('K8S_EVENTS_STREAMER_INCOMING_WEB_HOOK_URL')
-   configuration = kubernetes.config.load_incluster_config()
-   v1 = kubernetes.client.CoreV1Api()
-   k8s_watch = kubernetes.watch.Watch()
-   logger.info("Configuration is OK")
+    while True:
+        logger.info("Processing events...")
+        for event in k8s_watch.stream(v1.list_namespaced_event, k8s_namespace_name):
+            logger.debug(str(event))
+            if is_message_type_delete(event) and skip_delete_events != False:
+                logger.debug('Event type DELETED and skip deleted events is enabled. Skip this one')
+                continue
+            if is_reason_in_skip_list(event, reasons_to_skip) == True:
+                logger.debug('Event reason is in the skip list. Skip it')
+                continue
+            message = format_k8s_event_to_slack_message(event, users_to_notify)
+            post_slack_message(slack_web_hook_url, message)
+        logger.info('No more events. Wait 30 sec and check again')
+        time.sleep(30)
 
-   while True:
-       logger.info("Processing events...")
-       for event in k8s_watch.stream(v1.list_namespaced_event, k8s_namespace_name):
-           logger.debug(str(event))
-           if is_message_type_delete(event) and skip_delete_events != False:
-               logger.debug('Event type DELETED and skip deleted events is enabled. Skip this one')
-               continue
-           if is_reason_in_skip_list(event, reasons_to_skip) == True:
-               logger.debug('Event reason is in the skip list. Skip it')
-               continue
-           message = format_k8s_event_to_slack_message(event, users_to_notify)
-           post_slack_message(slack_web_hook_url, message)
-       logger.info('No more events. Wait 30 sec and check again')
-       time.sleep(30)
-
-   logger.info("Done")
+    logger.info("Done")
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Reformats the script with PEP8 standard spacing.

Reformats the Slack messages to be a little more digestible.

Adds the ability to regex blacklist by entity name.